### PR TITLE
feat: add dynamic color coding based on PR severity (#97)

### DIFF
--- a/.github/workflows/notify-on-pr.yaml
+++ b/.github/workflows/notify-on-pr.yaml
@@ -31,16 +31,20 @@ jobs:
           TOTAL=$((ADD + DEL))
           if [ "$TOTAL" -gt 1000 ]; then
             SEVERITY="error"
+            SEVERITY_COLOR="#ff4a8d"
           elif [ "$TOTAL" -gt 200 ]; then
             SEVERITY="warn"
+            SEVERITY_COLOR="#fcbb4f"
           else
             SEVERITY="info"
+            SEVERITY_COLOR="#8fa7ff"
           fi
 
           echo "Metrics: +$ADD / -$DEL | Files: $FILES | Commits: $COMMITS | Severity: $SEVERITY"
 
           # Export outputs for next step
           echo "severity=$SEVERITY" >> $GITHUB_OUTPUT
+          echo "severity_color=$SEVERITY_COLOR" >> $GITHUB_OUTPUT
           echo "additions=$ADD" >> $GITHUB_OUTPUT
           echo "deletions=$DEL" >> $GITHUB_OUTPUT
           echo "files=$FILES" >> $GITHUB_OUTPUT
@@ -53,7 +57,7 @@ jobs:
           username: "MagBridge CI"
           avatarUrl: "https://raw.githubusercontent.com/mag-bros/mag-bridge/assets-v1.2/.github/assets/terminator.png"
           severity: ${{ steps.pr_metrics.outputs.severity }}
-          color: "#0099ff"
+          color: ${{ steps.pr_metrics.outputs.severity_color }}
           title: "👀 Pull request ready for review!"
           description: |
             **Author:** `${{ github.event.pull_request.user.login }}`


### PR DESCRIPTION
##  Dynamic Color Coding for PR Notifications

Closes #97

### Changes
This PR adds dynamic color coding to Discord PR notifications based on the severity/size of the pull request.

### Implementation
- **Small PRs** (≤200 changes): Blue `#8fa7ff` 
- **Medium PRs** (>200 changes): Orange `#fcbb4f` 
- **Large PRs** (>1000 changes): Red `#ff4a8d` 

The color is now computed in the `Compute PR Metrics` step alongside the severity level and exported as `severity_color` output, which is then used by the Discord notification action.

### Before
All PR notifications had a hardcoded blue color `#0099ff`

### After
PR notifications now have visual indicators that make it easy to spot large/complex PRs at a glance in Discord! 